### PR TITLE
Replace special chars in preset name with _

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -5,6 +5,7 @@ import (
 	"github.com/brianvoe/gofakeit/v7"
 	"move-tool/ablmodels"
 	"strings"
+	"regexp"
 )
 
 func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numberOfSlices int) (err error) {
@@ -13,6 +14,10 @@ func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numb
 		return err
 	}
 	presetName := strings.ToLower(fmt.Sprintf("%s_%s", gofakeit.HipsterWord(), gofakeit.AdverbPlace()))
+	
+	re := regexp.MustCompile(`[^a-z]+`)
+	presetName = re.ReplaceAllString(strings.ToLower(presetName), "_")
+	
 	presetFolderPath, err := createFolderIfNotExist(outputFolderPath, presetName)
 	if err != nil {
 		return err

--- a/app/app.go
+++ b/app/app.go
@@ -5,8 +5,21 @@ import (
 	"github.com/brianvoe/gofakeit/v7"
 	"move-tool/ablmodels"
 	"strings"
-	"regexp"
 )
+
+func sanitizePresetName(presetName string) string {
+	var result strings.Builder
+
+	for _, char := range presetName {
+		if (char >= 'a' && char <= 'z') || char == '_' {
+			result.WriteRune(char)
+		} else {
+			result.WriteRune('_')
+		}
+	}
+
+	return result.String()
+}
 
 func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numberOfSlices int) (err error) {
 	err = gofakeit.Seed(0)
@@ -14,9 +27,7 @@ func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numb
 		return err
 	}
 	presetName := strings.ToLower(fmt.Sprintf("%s_%s", gofakeit.HipsterWord(), gofakeit.AdverbPlace()))
-	
-	re := regexp.MustCompile(`[^a-z]+`)
-	presetName = re.ReplaceAllString(strings.ToLower(presetName), "_")
+	presetName = sanitizePresetName(presetName)
 	
 	presetFolderPath, err := createFolderIfNotExist(outputFolderPath, presetName)
 	if err != nil {


### PR DESCRIPTION
summary of problem:
- the [hipster word list](https://github.com/brianvoe/gofakeit/blob/v7.0.0/data/hipster.go) in use for the first part of the preset name contains a mix of different formatted strings
- with mixed case is already dealt with via `strings.ToLower`
- whitespace remains
- this can lead to "ugly" filenames like `five dollar toast_downstairs.ablpresetbundle`

my solution:
- using `regexp` to replace everything but `a-z` with `_`

not sure if [brianvoe/gofakeit](https://github.com/brianvoe/gofakeit) provides a simpler way to get this result but fixing it like this was in reach for my capabilities.