### PR TITLE
Add support for custom preset names

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,12 +21,18 @@ func sanitizePresetName(presetName string) string {
 	return result.String()
 }
 
-func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numberOfSlices int) (err error) {
+func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numberOfSlices int, customPresetName string) (err error) {
 	err = gofakeit.Seed(0)
 	if err != nil {
 		return err
 	}
-	presetName := strings.ToLower(fmt.Sprintf("%s_%s", gofakeit.HipsterWord(), gofakeit.AdverbPlace()))
+	
+	var presetName string
+	if customPresetName != "" {
+		presetName = customPresetName
+	} else {
+		presetName = strings.ToLower(fmt.Sprintf("%s_%s", gofakeit.HipsterWord(), gofakeit.AdverbPlace()))
+	}
 	presetName = sanitizePresetName(presetName)
 	
 	presetFolderPath, err := createFolderIfNotExist(outputFolderPath, presetName)

--- a/app/app.go
+++ b/app/app.go
@@ -32,8 +32,8 @@ func SliceSampleIntoDrumRack(inputFilePath string, outputFolderPath string, numb
 		presetName = customPresetName
 	} else {
 		presetName = strings.ToLower(fmt.Sprintf("%s_%s", gofakeit.HipsterWord(), gofakeit.AdverbPlace()))
+		presetName = sanitizePresetName(presetName)
 	}
-	presetName = sanitizePresetName(presetName)
 	
 	presetFolderPath, err := createFolderIfNotExist(outputFolderPath, presetName)
 	if err != nil {

--- a/cmd/slice.go
+++ b/cmd/slice.go
@@ -9,13 +9,14 @@ var (
 	input          string
 	output         string
 	numberOfSlices int
+	presetName     string
 
 	sliceCmd = &cobra.Command{
 		Use:   "slice",
 		Short: "Slices long sample into drum rack",
 		Long:  `Slice long sample into given number of equal numberOfSlices and creates a drum rack preset`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return app.SliceSampleIntoDrumRack(input, output, numberOfSlices)
+			return app.SliceSampleIntoDrumRack(input, output, numberOfSlices, presetName)
 		},
 	}
 )
@@ -27,5 +28,6 @@ func init() {
 	_ = sliceCmd.MarkFlagRequired("output")
 	sliceCmd.Flags().IntVarP(&numberOfSlices, "numberOfSlices", "n", 16, "Number of numberOfSlices")
 	_ = sliceCmd.MarkFlagRequired("numberOfSlices")
+	sliceCmd.Flags().StringVarP(&presetName, "preset-name", "p", "", "Custom name for the preset (without extension)")
 	rootCmd.AddCommand(sliceCmd)
 }


### PR DESCRIPTION
## Summary
- Add `--preset-name` flag to slice command allowing users to specify a custom name for the preset
- Maintain backward compatibility by generating random names when not specified
- Custom names are preserved as-is (no lowercase conversion)

## Test plan
- Run tool with --preset-name flag and verify the preset is created with the specified name
- Run tool without --preset-name flag and verify a random name is generated as before