### PR TITLE
Remove move-tool binary from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,12 @@ Temporary Items
 # iCloud generated files
 *.icloud
 
+# Go binaries
+move-tool
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
 # End of https://www.toptal.com/developers/gitignore/api/goland,macos


### PR DESCRIPTION
## Summary
- Removed the move-tool binary from Git tracking to reduce repository size
- Updated .gitignore to prevent binary files from being committed in the future
- Added specific patterns for Go binaries and shared objects

## Test plan
- Verify that the move-tool binary is no longer tracked in Git
- Check that newly built binaries are ignored by Git

🤖 Generated with [Claude Code](https://claude.ai/code)